### PR TITLE
Added in missing return statement.

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -155,7 +155,7 @@
         };
 
         $auth.isAuthenticated = function() {
-          Local.isAuthenticated();
+          return Local.isAuthenticated();
         };
 
         return $auth;


### PR DESCRIPTION
The Local.isAuthenticated function returns a boolean but the value is swallowed by this where I think it should be returned as the docs sound like the function is a getter.
