### PR TITLE
Fixes #28.  Adds 'scope' to 'requiredUrlParams' 

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -40,7 +40,7 @@
       redirectUri: window.location.origin + '/',
       scope: 'email',
       scopeDelimiter: ',',
-      requiredUrlParams: ['display'],
+      requiredUrlParams: ['display', 'scope',],
       display: 'popup',
       type: '2.0',
       popupOptions: {


### PR DESCRIPTION
So that scope will be passed to the authorization endpoint for facebook, this simply adds the scope to the requiredUrlParams.  It doesn't make much sense (to me) that we have a default scope, but that scope is not being passed.  

https://github.com/sahat/satellizer/issues/28
