### PR TITLE
Update interceptor to use correct config variable

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -445,7 +445,7 @@
         return {
           request: function(http_config) {
             if ($window.localStorage[config.tokenName]) {
-              config.headers.Authorization = 'Bearer ' + $window.localStorage[config.tokenName];
+              http_config.headers.Authorization = 'Bearer ' + $window.localStorage[config.tokenName];
             }
             return http_config;
           },


### PR DESCRIPTION
Since our request interceptor takes in config as a variable, it was impossible to find the token in local storage and the Authorization header was never being added.
