### PR TITLE
Updating e-mail validation for signup view in examples

### DIFF
--- a/examples/client/views/signup.html
+++ b/examples/client/views/signup.html
@@ -14,7 +14,7 @@
 
           <div class="form-group has-feedback" ng-class="{ 'has-error' : signupForm.email.$invalid && signupForm.email.$dirty }">
             <input class="form-control input-lg" type="email" id="email" name="email" ng-model="email" placeholder="Email" required 
-            ng-pattern="/^[a-z]+[a-z0-9._]+@[a-z]+\.[a-z.]{2,5}$/">
+            ng-pattern="/^[A-z]+[a-z0-9._]+@[a-z]+\.[a-z.]{2,5}$/">
             <span class="ion-at form-control-feedback"></span>
             <div class="help-block text-danger" ng-if="signupForm.email.$dirty" ng-messages="signupForm.email.$error">
               <div ng-message="required">Your email address is required.</div>


### PR DESCRIPTION
This is a minor thing - when validating the e-mail within `examples/client/views/signup.html`, it accepts e-mails with the form shown below: 

![before](https://cloud.githubusercontent.com/assets/1226900/4054315/5568a7cc-2d8d-11e4-8734-02e9f0ea7cee.png)

By using `ng-pattern` to further validate the e-mail, it produces this result:  

![screen shot 2014-08-26 at 10 04 40 pm](https://cloud.githubusercontent.com/assets/1226900/4054369/94e9acc4-2d8e-11e4-8e57-04bdb3087fe7.png)

The form will display an error message if the e-mail is not of the form `alphanumeric@<domain>.com`. This regex is not full-proof, but it will at least prevent e-mails of the form `alphanumeric@alphanumeric` from passing. 
