### PR TITLE
Restore oAuth defaults after usage

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -381,6 +381,7 @@
       var oauth2 = {};
 
       oauth2.open = function(options) {
+        var originalDefaults = angular.copy(defaults);
         angular.extend(defaults, options);
         var deferred = $q.defer();
         var url = oauth2.buildUrl();
@@ -399,6 +400,7 @@
             deferred.reject(error);
           });
 
+        defaults = originalDefaults;
         return deferred.promise;
       };
 
@@ -445,6 +447,7 @@
       var oauth1 = {};
 
       oauth1.open = function(options) {
+        var originalDefaults = angular.copy(defaults);
         angular.extend(defaults, options);
 
         var deferred = $q.defer();
@@ -463,6 +466,7 @@
             deferred.reject(response);
           });
 
+        defaults = originalDefaults;
         return deferred.promise;
       };
 


### PR DESCRIPTION
If you use let's say foursquare (based on your demo), you set some defaults to Popup a window. So far so good. Then you want to login via Google. The defaults will get updated to google, but since google doesn't define a name, foursquare is going to be used, meh, not a problem. Then you try foursquare again and then, it sets some `requiredUrlParams` , `optionalUrlParams`... (You can see them on the popup url). 

I don't think foursquare is gonna care about that, but imagine (I am null at `oauth` so maybe this example never comes to true):
- I don't want to send `scope` to Google, so I remove it.
- I logout, then I try Facebook which puts that `scope`.
- I logout, then I try Google again, and the `scope` will be there so that will be bad (supposing that does something bad)

Anyhow, we really need to restore our defaults after usage, there is no reason to not to.
