### PR TITLE
Group test injections, better testing

### DIFF
--- a/test/$authSpec.js
+++ b/test/$authSpec.js
@@ -1,8 +1,22 @@
 describe('$auth provider', function() {
+  var $auth, $httpBackend, Local, $location, $window;
 
   beforeEach(module('Satellizer'));
 
-  it('should be able to call login', inject(function($auth, $httpBackend) {
+  beforeEach(inject(function(_$auth_, _$httpBackend_, _Local_, _$location_, _$window_) {
+    $auth = _$auth_;
+    $httpBackend = _$httpBackend_;
+    Local = _Local_;
+    $location = _$location_;
+    $window = _$window_;
+  }));
+
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('should be able to call login', function() {
     var token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjp7Il9pZCI6IjUzZTU3ZDZiY2MzNmMxNTgwNzU4NDJkZCIsImVtYWlsIjoiZm9vQGJhci5jb20iLCJfX3YiOjB9LCJpYXQiOjE0MDc1NDg3ODI5NzMsImV4cCI6MTQwODE1MzU4Mjk3M30.1Ak6mij5kfkSi6d_wtPOx4yK7pS7ZFSiwbkL7AJbnYs';
     var user = { email: 'foo@bar.com', password: '1234' };
 
@@ -13,9 +27,9 @@ describe('$auth provider', function() {
 //    $httpBackend.flush();
 
 //    expect(angular.isFunction($auth.login)).toBe(true);
-  }));
+  });
 
-  it('should be able to handle login errors', inject(function($auth, $httpBackend) {
+  it('should be able to handle login errors', function() {
     var user = {
       email: 'foo@bar.com',
       password: '1234'
@@ -31,9 +45,9 @@ describe('$auth provider', function() {
     $httpBackend.flush();
 
     expect(rejected).toBe(true);
-  }));
+  });
 
-  it('should be able to call signup', inject(function($auth, $httpBackend, $location) {
+  it('should be able to call signup', function() {
     var user = {
       email: 'foo@bar.com',
       password: '1234'
@@ -47,9 +61,9 @@ describe('$auth provider', function() {
 
     expect(angular.isFunction($auth.signup)).toBe(true);
     expect($location.path()).toEqual('/login');
-  }));
+  });
 
-  it('should be able to handle signup errors', inject(function(Local, $httpBackend) {
+  it('should be able to handle signup errors', function() {
     var user = {
       email: 'foo@bar.com',
       password: '1234'
@@ -65,20 +79,20 @@ describe('$auth provider', function() {
     $httpBackend.flush();
 
     expect(rejected).toBe(true);
-  }));
+  });
 
-  it('should log out a user', inject(function($window, $location, $auth) {
+  it('should log out a user', function() {
     $auth.logout();
     expect($window.localStorage.jwtToken).toBeUndefined();
     expect($location.path()).toEqual('/');
-  }));
+  });
 
-  it('should have a signup function', inject(function($window, Local) {
+  it('should have a signup function', function() {
     expect(Local.signup).toBeDefined();
     expect(angular.isFunction(Local.signup)).toBe(true);
-  }));
+  });
 
-  it('should create a new user', inject(function($httpBackend, $location, Local) {
+  it('should create a new user', function() {
     var user = {
       email: 'john@email.com',
       password: '1234'
@@ -91,12 +105,12 @@ describe('$auth provider', function() {
     $httpBackend.flush();
 
     expect($location.path()).toEqual('/login');
-  }));
+  });
 
-  it('should have a isAuthenticated function', inject(function(Local) {
+  it('should have a isAuthenticated function', function() {
     var isAuthed = Local.isAuthenticated();
     expect(Local.isAuthenticated).toBeDefined();
     expect(isAuthed).toBe(false);
-  }));
+  });
 });
 

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -1,169 +1,173 @@
 describe('Configuration', function() {
 
-  var authProvider;
+  var $auth, $authProvider;
 
-  beforeEach(module('Satellizer', function($authProvider) {
-    authProvider = $authProvider;
+  beforeEach(module('Satellizer', function(_$authProvider_) {
+    $authProvider = _$authProvider_;
   }));
 
-  it('$auth factory should be defined', inject(function($auth) {
+  beforeEach(inject(function(_$auth_) {
+    $auth = _$auth_;
+  }));
+
+  it('$auth factory should be defined', function() {
     expect($auth).toBeDefined();
-  }));
+  });
 
-  it('should allow overriding logoutRedirect', inject(function($auth) {
-    var reset = authProvider.logoutRedirect;
-    authProvider.logoutRedirect = '/new_url';
-    expect(authProvider.logoutRedirect).toEqual('/new_url');
-    authProvider.logoutRedirect = reset;
-  }));
+  it('should allow overriding logoutRedirect', function() {
+    var reset = $authProvider.logoutRedirect;
+    $authProvider.logoutRedirect = '/new_url';
+    expect($authProvider.logoutRedirect).toEqual('/new_url');
+    $authProvider.logoutRedirect = reset;
+  });
 
   it('should allow overriding loginRedirect', function() {
-    var reset = authProvider.loginRedirect;
-    authProvider.loginRedirect = '/new_url';
-    expect(authProvider.loginRedirect).toEqual('/new_url');
-    authProvider.loginRedirect = reset;
+    var reset = $authProvider.loginRedirect;
+    $authProvider.loginRedirect = '/new_url';
+    expect($authProvider.loginRedirect).toEqual('/new_url');
+    $authProvider.loginRedirect = reset;
   });
 
   it('should allow overriding loginUrl', function() {
-    var reset = authProvider.loginUrl;
-    authProvider.loginUrl = '/api/login';
-    expect(authProvider.loginUrl).toEqual('/api/login');
-    authProvider.loginUrl = reset;
+    var reset = $authProvider.loginUrl;
+    $authProvider.loginUrl = '/api/login';
+    expect($authProvider.loginUrl).toEqual('/api/login');
+    $authProvider.loginUrl = reset;
   });
 
   it('should allow overriding signupUrl', function() {
-    var reset = authProvider.signupUrl;
-    authProvider.signupUrl = '/api/signup';
-    expect(authProvider.signupUrl).toEqual('/api/signup');
-    authProvider.signupUrl = reset;
+    var reset = $authProvider.signupUrl;
+    $authProvider.signupUrl = '/api/signup';
+    expect($authProvider.signupUrl).toEqual('/api/signup');
+    $authProvider.signupUrl = reset;
   });
 
   it('should allow overriding signupRedirect', function() {
-    var reset = authProvider.signupRedirect;
-    authProvider.signupRedirect = '/new_url';
-    expect(authProvider.signupRedirect).toEqual('/new_url');
-    authProvider.signupRedirect = reset;
+    var reset = $authProvider.signupRedirect;
+    $authProvider.signupRedirect = '/new_url';
+    expect($authProvider.signupRedirect).toEqual('/new_url');
+    $authProvider.signupRedirect = reset;
   });
 
   it('should allow overriding loginRoute', function() {
-    var reset = authProvider.loginRoute;
-    authProvider.loginRoute = '/sign_in';
-    expect(authProvider.loginRoute).toEqual('/sign_in');
-    authProvider.loginRoute = reset;
+    var reset = $authProvider.loginRoute;
+    $authProvider.loginRoute = '/sign_in';
+    expect($authProvider.loginRoute).toEqual('/sign_in');
+    $authProvider.loginRoute = reset;
   });
 
   it('should allow overriding signupRoute', function() {
-    var reset = authProvider.signupRoute;
-    authProvider.signupRoute = '/register';
-    expect(authProvider.signupRoute).toEqual('/register');
-    authProvider.signupRoute = reset;
+    var reset = $authProvider.signupRoute;
+    $authProvider.signupRoute = '/register';
+    expect($authProvider.signupRoute).toEqual('/register');
+    $authProvider.signupRoute = reset;
   });
 
   it('should allow overriding user', function() {
-    var reset = authProvider.user;
-    authProvider.user = 'user';
-    expect(authProvider.user).toEqual('user');
-    authProvider.user = reset;
+    var reset = $authProvider.user;
+    $authProvider.user = 'user';
+    expect($authProvider.user).toEqual('user');
+    $authProvider.user = reset;
   });
 
   it('should allow overriding tokenName', function() {
-    var reset = authProvider.tokenName;
-    authProvider.tokenName = 'access_token';
-    expect(authProvider.tokenName).toEqual('access_token');
-    authProvider.tokenName = reset;
+    var reset = $authProvider.tokenName;
+    $authProvider.tokenName = 'access_token';
+    expect($authProvider.tokenName).toEqual('access_token');
+    $authProvider.tokenName = reset;
   });
 
   it('should allow overriding tokenPrefix', function() {
-    var reset = authProvider.tokenPrefix;
-    authProvider.tokenPrefix = 'myapp';
-    expect(authProvider.tokenPrefix).toEqual('myapp');
-    authProvider.tokenPrefix = reset;
+    var reset = $authProvider.tokenPrefix;
+    $authProvider.tokenPrefix = 'myapp';
+    expect($authProvider.tokenPrefix).toEqual('myapp');
+    $authProvider.tokenPrefix = reset;
   });
 
   it('should allow overriding unlinkUrl', function() {
-    var reset = authProvider.unlinkUrl;
-    authProvider.unlinkUrl = '/disconnect/';
-    expect(authProvider.unlinkUrl).toEqual('/disconnect/');
-    authProvider.unlinkUrl = reset;
+    var reset = $authProvider.unlinkUrl;
+    $authProvider.unlinkUrl = '/disconnect/';
+    expect($authProvider.unlinkUrl).toEqual('/disconnect/');
+    $authProvider.unlinkUrl = reset;
   });
 
   it('should have facebook method', function() {
-    expect(authProvider.facebook).toBeDefined();
+    expect($authProvider.facebook).toBeDefined();
   });
 
   it('should have google method', function() {
-    expect(authProvider.google).toBeDefined();
+    expect($authProvider.google).toBeDefined();
   });
 
   it('should have linkedin method', function() {
-    expect(authProvider.linkedin).toBeDefined();
+    expect($authProvider.linkedin).toBeDefined();
   });
 
   it('should have twitter method', function() {
-    expect(authProvider.twitter).toBeDefined();
+    expect($authProvider.twitter).toBeDefined();
   });
 
   it('should have oauth1', function() {
-    expect(authProvider.oauth1).toBeDefined();
+    expect($authProvider.oauth1).toBeDefined();
   });
 
   it('should have oauth2 method', function() {
-    expect(authProvider.oauth2).toBeDefined();
+    expect($authProvider.oauth2).toBeDefined();
   });
 
 
   it('should update a facebook provider with new params', function() {
-    authProvider.facebook({
+    $authProvider.facebook({
       scope: 'profile'
     });
-    expect(authProvider.providers.facebook.scope).toBe('profile');
+    expect($authProvider.providers.facebook.scope).toBe('profile');
   });
 
   it('should update a google provider with new params', function() {
-    authProvider.google({
+    $authProvider.google({
       state: 'secret'
     });
-    expect(authProvider.providers.google.state).toBe('secret');
+    expect($authProvider.providers.google.state).toBe('secret');
   });
 
   it('should update a github provider with new params', function() {
-    authProvider.github({
+    $authProvider.github({
       scope: 'email'
     });
-    expect(authProvider.providers.github.scope).toBe('email');
+    expect($authProvider.providers.github.scope).toBe('email');
   });
 
   it('should update a linkedin provider with new params', function() {
-    authProvider.linkedin({
+    $authProvider.linkedin({
       state: 'secret'
     });
-    expect(authProvider.providers.linkedin.state).toBe('secret');
+    expect($authProvider.providers.linkedin.state).toBe('secret');
   });
 
   it('should update a twitter provider with new params', function() {
-    authProvider.twitter({
+    $authProvider.twitter({
       url: '/oauth/twitter'
     });
-    expect(authProvider.providers.twitter.url).toBe('/oauth/twitter');
+    expect($authProvider.providers.twitter.url).toBe('/oauth/twitter');
   });
 
   it('should add a new oauth2 provider', function() {
-    authProvider.oauth2({
+    $authProvider.oauth2({
       name: 'github',
       url: '/auth/github',
       authorizationEndpoint: 'https://github.com/login/oauth/authorize'
     });
-    expect(angular.isObject(authProvider.providers['github'])).toBe(true);
-    expect(authProvider.providers['github'].name).toBe('github');
+    expect(angular.isObject($authProvider.providers['github'])).toBe(true);
+    expect($authProvider.providers['github'].name).toBe('github');
   });
 
   it('should add a new oauth1 provider', function() {
-    authProvider.oauth1({
+    $authProvider.oauth1({
       name: 'goodreads',
       url: '/auth/goodreads'
     });
-    expect(angular.isObject(authProvider.providers['goodreads'])).toBe(true);
-    expect(authProvider.providers['goodreads'].url).toBe('/auth/goodreads');
+    expect(angular.isObject($authProvider.providers['goodreads'])).toBe(true);
+    expect($authProvider.providers['goodreads'].url).toBe('/auth/goodreads');
   });
 
 });

--- a/test/localSpec.js
+++ b/test/localSpec.js
@@ -1,11 +1,26 @@
 describe('Local', function() {
+  var $auth, $httpBackend, Local, $location, $window;
+
   beforeEach(module('Satellizer'));
 
-  it('should have a login function', inject(function(Local) {
-    expect(angular.isFunction(Local.login)).toBe(true);
+  beforeEach(inject(function(_$auth_, _$httpBackend_, _Local_, _$location_, _$window_) {
+    $auth = _$auth_;
+    $httpBackend = _$httpBackend_;
+    Local = _Local_;
+    $location = _$location_;
+    $window = _$window_;
   }));
 
-  it('should return a user object on successful login', inject(function($httpBackend, Local) {
+  afterEach(function() {
+    $httpBackend.verifyNoOutstandingExpectation();
+    $httpBackend.verifyNoOutstandingRequest();
+  });
+
+  it('should have a login function', function() {
+    expect(angular.isFunction(Local.login)).toBe(true);
+  });
+
+  it('should return a user object on successful login', function() {
     var result = null;
     var token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjp7Il9pZCI6IjUzZjYxZTEwNmZjNjFhNmMxM2I1Mjc4ZCIsImVtYWlsIjoic2FoYXQ_QG1lLmNvbSIsIl9fdiI6MH0sImlhdCI6MTQwODgyMTA5MTY3NiwiZXhwIjoxNDA5NDI1ODkxNjc2fQ.0l-ql-ZVjHiILMcMegNb3bNqapt3TZwjHy_ieduioiQ';
     var user = {
@@ -28,9 +43,9 @@ describe('Local', function() {
       email: user.email,
       __v: 0
     });
-  }));
+  });
 
-  it('should fail login with incorrect credentials', inject(function($httpBackend, Local) {
+  it('should fail login with incorrect credentials', function() {
     var result = null;
     var user = {
       email: 'foo@bar.com',
@@ -46,25 +61,25 @@ describe('Local', function() {
     $httpBackend.flush();
 
     expect(result).toEqual('Wrong email or password');
-  }));
+  });
 
-  it('should have a logout function', inject(function(Local) {
+  it('should have a logout function', function() {
     expect(Local.logout).toBeDefined();
     expect(angular.isFunction(Local.logout)).toBe(true);
-  }));
+  });
 
-  it('should log out a user', inject(function($window, $location, Local) {
+  it('should log out a user', function() {
     Local.logout();
     expect($window.localStorage.jwtToken).toBeUndefined();
     expect($location.path()).toEqual('/');
-  }));
+  });
 
-  it('should have a signup function', inject(function($window, Local) {
+  it('should have a signup function', function() {
     expect(Local.signup).toBeDefined();
     expect(angular.isFunction(Local.signup)).toBe(true);
-  }));
+  });
 
-  it('should unlink a provider successfully', inject(function($window, $httpBackend, Local) {
+  it('should unlink a provider successfully', function() {
     var result = null;
     var provider = 'google';
     var token = 'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyIjp7Il9pZCI6IjUzZjYxZTEwNmZjNjFhNmMxM2I1Mjc4ZCIsImVtYWlsIjoic2FoYXRAbWUuY29tIiwiX192IjowfSwiaWF0IjoxNDA4ODIxMDkxNjc2LCJleHAiOjE0MDk0MjU4OTE2NzZ9.0l-ql-ZVjHiILMcMegNb3bNqapt3TZwjHy_ieduioiQ';
@@ -77,10 +92,10 @@ describe('Local', function() {
 
     $httpBackend.flush();
 
-    expect(Local.unlink()).toBeDefined();
-  }));
+    expect(Local.unlink).toBeDefined();
+  });
 
-  it('should unlink a provider and get an error', inject(function($window, $httpBackend, Local) {
+  it('should unlink a provider and get an error', function() {
     var result = null;
     var provider = 'google';
 
@@ -93,9 +108,9 @@ describe('Local', function() {
     $httpBackend.flush();
 
     expect(result.status).toEqual(400);
-  }));
+  });
 
-  it('should create a new user', inject(function($httpBackend, $location, Local) {
+  it('should create a new user', function() {
     var user = {
       email: 'john@email.com',
       password: '1234'
@@ -108,11 +123,11 @@ describe('Local', function() {
     $httpBackend.flush();
 
     expect($location.path()).toEqual('/login');
-  }));
+  });
 
-  it('should have a isAuthenticated function', inject(function(Local) {
+  it('should have a isAuthenticated function', function() {
     expect(Local.isAuthenticated).toBeDefined();
     expect(angular.isFunction(Local.isAuthenticated)).toBe(true);
-  }));
+  });
 });
 

--- a/test/oauth2Spec.js
+++ b/test/oauth2Spec.js
@@ -1,38 +1,35 @@
 describe('OAuth 2.0 Login', function() {
-
-  var auth;
-  var httpBackend;
-  var oauth2;
+  var $auth, $httpBackend, Oauth2;
 
   beforeEach(module('Satellizer'));
 
-  beforeEach(inject(function($auth, $httpBackend, Oauth2) {
-    auth = $auth;
-    httpBackend = $httpBackend;
-    oauth2 = Oauth2;
+  beforeEach(inject(function(_$auth_, _$httpBackend_, _Oauth2_) {
+    $auth = _$auth_;
+    $httpBackend = _$httpBackend_;
+    Oauth2 = _Oauth2_;
   }));
 
   it('authenticate should be defined', function() {
-    expect(auth.authenticate).toBeDefined();
-    expect(angular.isFunction(auth.authenticate)).toBe(true);
+    expect($auth.authenticate).toBeDefined();
+    expect(angular.isFunction($auth.authenticate)).toBe(true);
   });
 
   it('should throw an error without provider name', function() {
     var authenticate = function() {
-      auth.authenticate();
+      $auth.authenticate();
     };
     expect(authenticate).toThrow();
   });
 
   it('should throw an error if provider name does not exist', function() {
     var authenticate = function() {
-      auth.authenticate('asdfqwerty');
+      $auth.authenticate('asdfqwerty');
     };
     expect(authenticate).toThrow();
   });
 
   it('should call open method', function() {
-    oauth2.open({
+    Oauth2.open({
       url: '/auth/facebook',
       authorizationEndpoint: 'https://www.facebook.com/dialog/oauth',
       redirectUri: window.location.origin + '/',
@@ -42,7 +39,7 @@ describe('OAuth 2.0 Login', function() {
       type: 'oauth2',
 
     });
-    expect(oauth2.open).toBeDefined();
+    expect(Oauth2.open).toBeDefined();
   });
 
 

--- a/test/popupSpec.js
+++ b/test/popupSpec.js
@@ -4,10 +4,11 @@ describe('Configuration', function() {
 
   beforeEach(module('Satellizer'));
 
-  beforeEach(inject(function(_Popup_, _$interval_, _$q_) {
+  beforeEach(inject(function(_Popup_, _$interval_, _$q_, _$window_) {
     Popup = _Popup_;
     $interval = _$interval_;
     $q = _$q_;
+    $window = _$window_;
   }));
 
 
@@ -31,7 +32,7 @@ describe('Configuration', function() {
   it('should open a new popup', function() {
     var open = Popup.open();
     $interval.flush(300);
-    window.postMessage('testing', '*');
+    $window.postMessage('testing', '*');
     expect(angular.isObject(open)).toBe(true);
   });
 


### PR DESCRIPTION
Today is the test day, my first goal was to do a little cleanup, there is no changes about the test themselves (that is my next step probably).

So, for DRY, I moved all the injection in all the files to the top (you were doing that in some files).

`$authSpec`, moved injections at the top, so when the naming changes come (lowercase services), it is better to change just one place and not 20.

Also, I added an `afterEach`. Basically you were testing like: This method MAY do a request. The idea is: it MAY and we ASSERT that. You were missing the last part. So the idea is: We establish what request are going to be done and that only those are made. If there is an extra request, please fail, if there is a request expected but not done, fail. That is what the `afterEach` does.

`testConfig`, changed `authProvider` to `$authProvider` makes more sense.

`localSpec`, same changes as `$authSpec`. Funny enough, you had a little error on one of the tests where you expected `Local.unlink()` to be defined. Well, defined is, but you were actually calling the function and that generated a non expected `GET`. With the `afterEach` that cries (good) so I just fixed the typo.

The rest of the tests are just minimum changes.

Next, check what tests makes sense. Which remembers me... the provider test, all those tests where you put a string and then test that the string is there are worthless. Luckily, if we do the constants again, that tests are going to change and make more sense.

Cheers.
