### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ or use the :globe_with_meridians: CDN:
 
 **Step 1. App Module**
 ```js
-angular.module('MyApp', ['satellizer'])
+angular.module('MyApp', ['Satellizer'])
   .config(function($authProvider) {
     
     $authProvider.facebook({


### PR DESCRIPTION
fixed typo in Usage section, of Satellizer from lowercase to uppercase first letter
