### PR TITLE
Redirect after unlink

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -188,12 +188,16 @@
           var namespace = [config.tokenPrefix, config.tokenName].join('_');
           $window.localStorage[namespace] = token;
 
+          this.redirect(deferred);
+        };
+
+        shared.redirect = function(deferred) {
           if (config.loginRedirect) {
             $location.path(config.loginRedirect);
           }
 
           deferred.resolve();
-        };
+        }
 
         shared.isAuthenticated = function() {
           var token = [config.tokenPrefix, config.tokenName].join('_');
@@ -244,7 +248,7 @@
 
           $http.get(config.unlinkUrl + provider)
             .then(function(response) {
-              shared.parseUser(response.data[config.tokenName], deferred);
+              shared.redirect(deferred);
             })
             .catch(function(response) {
               deferred.reject(response);


### PR DESCRIPTION
Added redirect function to `satellizer.shared` service and call it from unlink to bypass resetting token, since the server is expected to only send a 200 response from `unlink`.
