### PR TITLE
[Enhancement]: Make the HTTP auth header configurable.

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -9,6 +9,7 @@
 
   angular.module('satellizer', [])
     .constant('satellizer.config', {
+      authHeader: 'Authorization',
       loginOnSignup: true,
       loginRedirect: '/',
       logoutRedirect: '/',
@@ -80,6 +81,10 @@
     })
     .provider('$auth', ['satellizer.config', function(config) {
       Object.defineProperties(this, {
+        authHeader: {
+          get: function() { return config.authHeader; },
+          set: function(value) { config.authHeader = value; }
+        },
         logoutRedirect: {
           get: function() { return config.logoutRedirect; },
           set: function(value) { config.logoutRedirect = value; }
@@ -598,8 +603,10 @@
         var tokenName = config.tokenPrefix ? config.tokenPrefix + '_' + config.tokenName : config.tokenName;
         return {
           request: function(httpConfig) {
-            if (localStorage.getItem(tokenName)) {
-              httpConfig.headers.Authorization = 'Bearer ' + localStorage.getItem(tokenName);
+            var token = localStorage.getItem(tokenName);
+            if (token) {
+              token = config.authHeader === 'Authorization' ? 'Bearer ' + token : token;
+              httpConfig.headers[config.authHeader] = token;
             }
             return httpConfig;
           },

--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -29,6 +29,12 @@ describe('satellizer.config', function() {
     expect(this.$authProvider.signupRedirect).toEqual('/newurl');
   });
 
+  it('should set authHeader', function() {
+    this.$authProvider.authHeader = 'x-new-header';
+    expect(this.config.authHeader).toEqual('x-new-header');
+    expect(this.$authProvider.authHeader).toEqual('x-new-header');
+  });
+
   it('should get loginOnSignup', function() {
     this.$authProvider.loginOnSignup = true;
     expect(this.config.loginOnSignup).toEqual(true);

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -1,0 +1,50 @@
+describe('$http', function() {
+
+  beforeEach(function() {
+    var _this = this;
+    module('satellizer', function($authProvider) {
+      _this.$authProvider = $authProvider;
+    });
+  });
+
+  beforeEach(inject(['$httpBackend', '$auth','satellizer.config', 'satellizer.local',
+    function($httpBackend, $auth, config, local) {
+      var mockResponse  = {};
+      this.$httpBackend = $httpBackend;
+      this.$auth        = $auth;
+      this.config       = config;
+      this.local        = local;
+
+      mockResponse[this.config.tokenName] = 'ABCDEFG123456';
+      $httpBackend.expectPOST(this.config.loginUrl).respond(mockResponse);
+  }]));
+
+  it('should handle the default Authorization header', function() {
+    var _this = this;
+    this.$authProvider.authHeader = 'Authorization';
+    this.local.login()
+      .then(function(response) { return response.config.headers; })
+      .then(function(headers) {
+        token = headers[_this.config.authHeader]
+        expect(token).toBeDefined();
+        expect(token).toMatch(/Bearer\s+\w+/);
+      });
+
+    this.$httpBackend.flush()
+  });
+
+  it('should handle a custom header', function() {
+    var _this = this;
+    this.$authProvider.authHeader = 'x-new-header';
+    this.local.login()
+      .then(function(response) { return response.config.headers; })
+      .then(function(headers) {
+        token = headers[_this.config.authHeader]
+        expect(token).toBeDefined();
+        expect(token).not.toMatch(/Bearer\s+\w+/);
+      });
+
+    this.$httpBackend.flush()
+  });
+
+});


### PR DESCRIPTION
I've already detailed why this is desirable in #169, but here's a PR to address!  The code below is the change that I've been using locally, along with added specs.

**EDIT:** Appears that the Travis build is failing. Not entirely sure why, tests are passing locally... I'll diagnose tomorrow morning.
