### PR TITLE
[Fix]: Amend failing Travis specs.

### DIFF
--- a/test/config.spec.js
+++ b/test/config.spec.js
@@ -30,9 +30,13 @@ describe('satellizer.config', function() {
   });
 
   it('should set authHeader', function() {
+    var configDefault = this.$authProvider.authHeader;
+
     this.$authProvider.authHeader = 'x-new-header';
     expect(this.config.authHeader).toEqual('x-new-header');
     expect(this.$authProvider.authHeader).toEqual('x-new-header');
+
+    this.$authProvider.authHeader = configDefault;
   });
 
   it('should get loginOnSignup', function() {

--- a/test/http.spec.js
+++ b/test/http.spec.js
@@ -1,24 +1,30 @@
 describe('$http', function() {
 
   beforeEach(function() {
-    var _this = this;
+    var self = this;
     module('satellizer', function($authProvider) {
-      _this.$authProvider = $authProvider;
+      self.$authProvider = $authProvider;
     });
   });
 
   beforeEach(inject([
+    '$http',
     '$httpBackend',
-    '$auth',
+    '$window',
     'satellizer.config',
     'satellizer.local',
-    function($httpBackend, $auth, config, local) {
+    'satellizer.shared',
+    function($http, $httpBackend, $window, config, local, shared) {
       var mockResponse = {};
 
+      this.$http = $http;
       this.$httpBackend = $httpBackend;
-      this.$auth = $auth;
+      this.$window = $window;
       this.config = config;
       this.local = local;
+      this.shared = shared;
+
+      $window.localStorage.clear();
 
       mockResponse[this.config.tokenName] = 'ABCDEFG123456';
       $httpBackend.expectPOST(this.config.loginUrl).respond(mockResponse);
@@ -26,35 +32,41 @@ describe('$http', function() {
 
   it('should handle the default Authorization header', function() {
     var self = this;
-    this.$authProvider.authHeader = 'Authorization';
-    this.local.login()
-      .then(function(response) {
-        return response.config.headers;
-      })
-      .then(function(headers) {
-        var token = headers[self.config.authHeader];
-        expect(token).toBeDefined();
-        expect(token).toMatch(/Bearer\s+\w+/);
-      });
 
+    this.local.login()
+    this.$httpBackend.flush()
+
+    this.$httpBackend.expectGET('/some/arbitrary/endpoint', function(headers) {
+      var token = headers[self.config.authHeader];
+      expect(token).toBeDefined();
+      expect(token).toMatch(/Bearer\s+\w+/);
+      return headers;
+    }).respond(200);
+
+    this.$http.get('/some/arbitrary/endpoint');
     this.$httpBackend.flush();
   });
 
   it('should handle a custom header', function() {
-    var _this = this;
+    var self = this;
     this.$authProvider.authHeader = 'x-new-header';
+
     this.local.login()
-      .then(function(response) {
-        return response.config.headers;
-      })
-      .then(function(headers) {
-        var token = headers[_this.config.authHeader];
-        expect(token).toBeDefined();
-        expect(token).not.toMatch(/Bearer\s+\w+/);
-      });
+    this.$httpBackend.flush()
 
+    this.$httpBackend.expectGET('/some/arbitrary/endpoint', function(headers) {
+      var token = headers[self.config.authHeader];
+      expect(token).toBeDefined();
+      expect(token).not.toMatch(/Bearer\s+\w+/);
+      return headers;
+    }).respond(200);
+
+    this.$http.get('/some/arbitrary/endpoint');
     this.$httpBackend.flush();
+  });
 
+  afterEach(function() {
+    this.shared.logout();
     this.$authProvider.authHeader = 'Authorization';
   });
 


### PR DESCRIPTION
Fixed failing Travis build due to changes introduced by #171 (although tests passed locally).

The TL;DR is that I'm an idiot and the flow wasn't completely correct.  **_However**_, one important thing to note is that the reason it passed locally was due to shared mutable state (particularly due to changes made by `config.spec.js`) and a race condition of sorts that had different behavior on Travis.

So, with that said, although it's probably outside of the scope of this PR, some work probably needs to be done to either sandbox existing tests and/or to add more extensive cleanup. As-is, it's dangerous in that the existing state carried between spec suites could provide false negatives (like in my case) or even worse, false positives.

A few examples while it's still fresh -- the state as it exists before the first test in `http.spec.js` is run: 
- `window.localStorage` - Several tokens present. Because some of the `satellizer.js` logic depends on whether a token is present or not, it could lead to unexpected results.
- Most of `config` are the altered values after `config.spec.js` takes place. For instance, although I dynamically use `config.loginUrl` so it doesn't technically matter (versus if I were trying to hit an exact route), as of my specs running, that route pointed to `/api/signin`.
