### PR TITLE
unnecessary first() method in BaseController Laravel php

### DIFF
--- a/examples/server/php/app/controllers/BaseController.php
+++ b/examples/server/php/app/controllers/BaseController.php
@@ -17,7 +17,7 @@ class BaseController extends Controller {
     protected function createToken($user)
     {
         $payload = array(
-            'sub' => $user->first()->id,
+            'sub' => $user->id,
             'iat' => time(),
             'exp' => time() + (2 * 7 * 24 * 60 * 60) // 14 days
         );


### PR DESCRIPTION
This don't affects satellizer itself but I was having problem with the createToken method in the BaseController in Laravel. The problem arose when I logged in with another user. The first() method is unneeded and gives problem.
