### PR TITLE
$auth.setToken(token, isLinking): "isLinking" to "isRedirect" ?

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ $auth.getPayload();
 Saves a JWT or an access token to Local Storage. *It is mostly used internally.*
 
 - **token** - An object that takes a JWT (`response.data[config.tokenName]`) or an access token (`response.access_token`).
-- **isLinking** - An optional boolean value that controls whether or not to redirect to `loginRedirect` route after saving a token. Defaults to `false`.
+- **isLinking** - An optional boolean value that controls whether or not to redirect to `loginRedirect` route after saving a token. Defaults to `true`.
 
 <hr>
 

--- a/satellizer.js
+++ b/satellizer.js
@@ -256,7 +256,7 @@
 
           $window.localStorage[tokenName] = token;
 
-          if (config.loginRedirect && !isLinking) {
+          if (config.loginRedirect && isLinking) {
             $location.path(config.loginRedirect);
           }
         };

--- a/satellizer.js
+++ b/satellizer.js
@@ -247,6 +247,7 @@
         };
 
         shared.setToken = function(response, isLinking) {
+          isLinking = isLinking || true; // default to true
           var token = response.access_token || response.data[config.tokenName];
           var tokenName = config.tokenPrefix ? config.tokenPrefix + '_' + config.tokenName : config.tokenName;
 


### PR DESCRIPTION
As the [api document](https://github.com/sahat/satellizer#authsettokentoken-islinking) describes, the `isLinking` defaults to `false`, it seems this action won't redirect to any other url if the param `isLinking` is missing...

But when I call `$auth.setToken` in my code like this, it jumps to `$config.loginRedirect`:

```javascript
$auth.setToken(data.token);
```

Then I tried the other side it works...

```javascript
$auth.setToken(data.token, true);
```

Here's the fix.