### PR TITLE
verify provided JWT token [security fix]

### DIFF
--- a/examples/server/java/src/main/java/com/example/helloworld/auth/AuthFilter.java
+++ b/examples/server/java/src/main/java/com/example/helloworld/auth/AuthFilter.java
@@ -12,6 +12,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.nimbusds.jose.JOSEException;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 
@@ -21,7 +22,9 @@ public class AuthFilter implements Filter {
 	
 	private static final String AUTH_ERROR_MSG = "Please make sure your request has an Authorization header",
 								EXPIRE_ERROR_MSG = "Token has expired",
-								JWT_ERROR_MSG = "Unable to parse JWT";
+								JWT_ERROR_MSG = "Unable to parse JWT",
+								JWT_INVALID_MSG = "Invalid JWT token"
+	;
 								
 
 	@Override
@@ -40,7 +43,13 @@ public class AuthFilter implements Filter {
 				claimSet = (JWTClaimsSet) AuthUtils.decodeToken(authHeader);
 			} catch (ParseException e) {
 				httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, JWT_ERROR_MSG);
+				return;
+			} catch (JOSEException e) {
+				httpResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, JWT_INVALID_MSG);
+				return;
 			}
+
+
 			// ensure that the token is not expired
 			if (new DateTime(claimSet.getExpirationTime()).isBefore(DateTime.now())) {
 				httpResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED, EXPIRE_ERROR_MSG);

--- a/examples/server/java/src/main/java/com/example/helloworld/auth/AuthUtils.java
+++ b/examples/server/java/src/main/java/com/example/helloworld/auth/AuthUtils.java
@@ -2,6 +2,7 @@ package com.example.helloworld.auth;
 
 import java.text.ParseException;
 
+import com.nimbusds.jose.crypto.MACVerifier;
 import org.joda.time.DateTime;
 
 import com.example.helloworld.core.Token;
@@ -20,12 +21,17 @@ public final class AuthUtils {
 	private static final String TOKEN_SECRET = "aliceinwonderland";
 	public static final String AUTH_HEADER_KEY = "Authorization";
 	
-	public static String getSubject(String authHeader) throws ParseException {
+	public static String getSubject(String authHeader) throws ParseException, JOSEException {
 		return decodeToken(authHeader).getSubject();
 	}
 	
-	public static ReadOnlyJWTClaimsSet decodeToken(String authHeader) throws ParseException {
-		return SignedJWT.parse(getSerializedToken(authHeader)).getJWTClaimsSet();
+	public static ReadOnlyJWTClaimsSet decodeToken(String authHeader) throws ParseException, JOSEException {
+		SignedJWT signedJWT = SignedJWT.parse(getSerializedToken(authHeader));
+		if (signedJWT.verify(new MACVerifier(TOKEN_SECRET))) {
+			return signedJWT.getJWTClaimsSet();
+		} else {
+			throw new JOSEException("Signature verification failed");
+		}
 	}
 	
 	public static Token createToken(String host, long sub) throws JOSEException {

--- a/examples/server/java/src/main/java/com/example/helloworld/resources/AuthResource.java
+++ b/examples/server/java/src/main/java/com/example/helloworld/resources/AuthResource.java
@@ -198,7 +198,7 @@ public class AuthResource {
 	@UnitOfWork
 	public Response unlink(@PathParam("provider") String provider,
 			@Context HttpServletRequest request) throws ParseException, IllegalArgumentException,
-			IllegalAccessException, NoSuchFieldException, SecurityException {
+			IllegalAccessException, NoSuchFieldException, SecurityException, JOSEException {
 		String subject = AuthUtils.getSubject(request.getHeader(AuthUtils.AUTH_HEADER_KEY));
 		Optional<User> foundUser = dao.findById(Long.parseLong(subject));
 

--- a/examples/server/java/src/main/java/com/example/helloworld/resources/UserResource.java
+++ b/examples/server/java/src/main/java/com/example/helloworld/resources/UserResource.java
@@ -1,5 +1,6 @@
 package com.example.helloworld.resources;
 
+import com.nimbusds.jose.JOSEException;
 import io.dropwizard.hibernate.UnitOfWork;
 import io.dropwizard.jersey.errors.ErrorMessage;
 
@@ -35,7 +36,7 @@ public class UserResource {
 
 	@GET
 	@UnitOfWork
-	public Response getUser(@Context HttpServletRequest request) throws ParseException {
+	public Response getUser(@Context HttpServletRequest request) throws ParseException, JOSEException {
 		Optional<User> foundUser = getAuthUser(request);
 		
 		if (!foundUser.isPresent()) {
@@ -54,7 +55,7 @@ public class UserResource {
 
 	@PUT
 	@UnitOfWork
-	public Response updateUser(@Valid User user, @Context HttpServletRequest request) throws ParseException {
+	public Response updateUser(@Valid User user, @Context HttpServletRequest request) throws ParseException, JOSEException {
 		Optional<User> foundUser = getAuthUser(request);
 		
 		if (!foundUser.isPresent()) {
@@ -74,7 +75,7 @@ public class UserResource {
 	/*
 	 * Helper methods
 	 */	
-	private Optional<User> getAuthUser(HttpServletRequest request) throws ParseException {
+	private Optional<User> getAuthUser(HttpServletRequest request) throws ParseException, JOSEException {
 		String subject = AuthUtils.getSubject(request.getHeader(AuthUtils.AUTH_HEADER_KEY));
 		return dao.findById(Long.parseLong(subject));
 	}


### PR DESCRIPTION
The JWT token provided is not verified in the filter, so one can easily pretend to be anybody else.

I tested to use a JWT token generated with another secret on jwt.io, and successfully logged in on previous version of the app. Now with this fix a token signed with a different secret is properly rejected.