### PR TITLE
Fixed httpInterceptor config bug

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -150,6 +150,10 @@
         authHeader: {
           get: function() { return config.authHeader; },
           set: function(value) { config.authHeader = value; }
+        },
+        httpInterceptor: {
+          get: function() { return config.httpInterceptor; },
+          set: function(value) { config.httpInterceptor = value; }
         }
       });
 
@@ -607,24 +611,22 @@
       };
     })
     .config(['$httpProvider', 'satellizer.config', function($httpProvider, config) {
-      if (config.httpInterceptor) {
-        $httpProvider.interceptors.push(['$q', function($q) {
-          var tokenName = config.tokenPrefix ? config.tokenPrefix + '_' + config.tokenName : config.tokenName;
-          return {
-            request: function(httpConfig) {
-              var token = localStorage.getItem(tokenName);
-              if (token) {
-                token = config.authHeader === 'Authorization' ? 'Bearer ' + token : token;
-                httpConfig.headers[config.authHeader] = token;
-              }
-              return httpConfig;
-            },
-            responseError: function(response) {
-              return $q.reject(response);
+      $httpProvider.interceptors.push(['$q', function($q) {
+        var tokenName = config.tokenPrefix ? config.tokenPrefix + '_' + config.tokenName : config.tokenName;
+        return {
+          request: function(httpConfig) {
+            var token = localStorage.getItem(tokenName);
+            if (token && config.httpInterceptor) {
+              token = config.authHeader === 'Authorization' ? 'Bearer ' + token : token;
+              httpConfig.headers[config.authHeader] = token;
             }
-          };
-        }]);
-      }
+            return httpConfig;
+          },
+          responseError: function(response) {
+            return $q.reject(response);
+          }
+        };
+      }]);
     }]);
 
 })(window, window.angular);


### PR DESCRIPTION
After setting `$authProvider.httpInterceptor = false;` in my app config I was still getting the Authorization header in my HTTP requests.

After a little :mag_right:  I found https://github.com/sahat/satellizer/issues/201 and https://github.com/sahat/satellizer/issues/250 to be related.

First thing missing was the getter/setter.

The second issue is the `if (config.httpInterceptor)` inside the `.config()`. This code will run **before** the user's app config. So this was always going to be `true` (default value). So I moved the check inside the returned function.

