### PR TITLE
Removed extra scope on windows live.

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -95,7 +95,7 @@
           url: '/auth/live',
           authorizationEndpoint: 'https://login.live.com/oauth20_authorize.srf',
           redirectUri: window.location.origin || window.location.protocol + '//' + window.location.host,
-          scope: ['wl.basic', 'wl.emails'],
+          scope: ['wl.emails'],
           scopeDelimiter: ' ',
           requiredUrlParams: ['display', 'scope'],
           display: 'popup',


### PR DESCRIPTION
I removed the wl.basic scope because it requests the users contact list which is an instant turn off... Without it you get the basic profile info (name, id, gender and locale).

https://msdn.microsoft.com/en-us/library/hh243646.aspx