### PR TITLE
Provider popup blocked fix

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -586,7 +586,10 @@
               }
             } catch (error) {}
 
-            if (popupWindow.closed) {
+            if (!popupWindow) {
+              $interval.cancel(polling);
+              deferred.reject({ data: 'Provider Popup Blocked' });
+            } else if (popupWindow.closed) {
               $interval.cancel(polling);
               deferred.reject({ data: 'Authorization Failed' });
             }


### PR DESCRIPTION
When the authorization provider popup is blocked by the browser, the popupWindow object's properties will be undefined, so accessing popupWindow.closed will be undefined. This fix checks for the existence of the popup window before testing it's properties, and returns an error reporting the failure to the caller if the popup window was never opened. This is a solution for issue #277.