### PR TITLE
Pluggable authentication strategies/mechanisms

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -352,11 +352,12 @@
         };
 
         providerAuth.authenticate = function(name, isLinking, userData) {
+          var strategy = providerAuth.resolveToStrategy(config.providers[name]);
+          if(strategy === null) return $q.reject('Failed to resolve provider config to strategy');
 
-          var provider = providerAuth.resolveToStrategy(config.providers[name]);
           var deferred = $q.defer();
 
-          provider.open(config.providers[name], userData || {})
+          strategy.open(config.providers[name], userData || {})
             .then(function(response) {
               shared.setToken(response, isLinking);
               deferred.resolve(response);

--- a/test/provider_auth.spec.js
+++ b/test/provider_auth.spec.js
@@ -1,0 +1,122 @@
+describe('satellizer.provider_auth', function() {
+
+  beforeEach(module('satellizer'));
+
+  beforeEach(inject(['$q', '$timeout','$httpBackend', '$location', '$window', 'satellizer.config', 'satellizer.shared', 'satellizer.provider_auth',
+    function($q, $timeout, $httpBackend, $location, $window, config, shared, providerAuth) {
+      this.$q = $q;
+      this.$httpBackend = $httpBackend;
+      this.$location = $location;
+      this.$window = $window;
+      this.config = config;
+      this.shared = shared;
+      this.$timeout = $timeout;
+      this.providerAuth = providerAuth;
+    }]));
+
+  describe('definitions', function() {
+    it('should define addStrategy()', function() {
+      expect(this.providerAuth.addStrategy).toBeDefined();
+    });
+
+    it('should define resolveToStrategy()', function() {
+      expect(this.providerAuth.resolveToStrategy).toBeDefined();
+    });
+
+    it('should define authenticate()', function() {
+      expect(this.providerAuth.authenticate).toBeDefined();
+    });
+  });
+
+  describe('implementation', function() {
+
+    beforeEach(function() {
+      var $q = this.$q;
+      this.mockStrategy = new function() {
+        var mock = {};
+
+        mock.id = 'mock';
+
+        mock.open = function(options, userData) {
+          return $q.when({data: {tokenRoot: { access_token: 'foo' }}});
+        };
+
+        mock.applies = function(provider_config) {
+          return provider_config.type === mock.id;
+        };
+        return mock;
+      };
+
+      this.anotherMockStrategy = new function() {
+        var mock = {};
+
+        mock.id = 'another';
+
+        mock.open = function(options, userData) {
+          return $q.when({data: {tokenRoot: { access_token: 'bar' }}});
+        };
+        mock.applies = function(provider_config) {
+          return provider_config.type === mock.id;
+        };
+        return mock;
+      };
+
+      this.config.providers = {
+        mockProvider: {
+          type: 'mock'
+        },
+        anotherMockProvider: {
+          type: 'another'
+        }
+      };
+
+      this.providerAuth.addStrategy(this.mockStrategy);
+    });
+
+
+    describe('resolveToStrategy()', function() {
+      beforeEach(function() {
+        spyOn(this.providerAuth, 'resolveToStrategy').andCallThrough();
+        this.strategy = this.providerAuth.resolveToStrategy(this.config.providers['mockProvider']);
+      });
+
+      it('should resolve correctly', function() {
+        expect(this.strategy.id).toEqual('mock')
+      });
+    });
+
+    describe('authenticate()', function() {
+      beforeEach(function() {
+        spyOn(this.providerAuth, 'resolveToStrategy').andCallThrough();
+        this.providerAuth.authenticate('mockProvider', false, {});
+      });
+
+      it('should call resolveToStrategy()', function() {
+        expect(this.providerAuth.resolveToStrategy).toHaveBeenCalled();
+      });
+
+      it('should make a check with applies()', function() {
+        spyOn(this.mockStrategy, 'applies').andCallThrough();
+        this.providerAuth.resolveToStrategy(this.config.providers.mockProvider);
+        expect(this.mockStrategy.applies).toHaveBeenCalled();
+      });
+
+      it('should deliver token', function() {
+        var holder = {
+          assertToken: function(response) {
+            expect(response.data.tokenRoot.access_token).toBe('foo')
+          }
+        };
+        spyOn(holder, 'assertToken').andCallThrough();
+
+        this.providerAuth.authenticate('mockProvider', false, {}).then(holder.assertToken);
+        this.$timeout.flush();
+
+        expect(holder.assertToken).toHaveBeenCalled();
+      });
+    });
+  });
+
+
+
+});


### PR DESCRIPTION
Satellizer provides nice abstractions to configure and handle 2- or 3-party authentication mechanisms. This PR enables one to go beyond OAuth or add own OAuth handlers, *while keeping full backwards compatibility*.

In details this PR:
1. introduces concept of `strategy` (plug from ruby's omniauth)
2. refactors `satellizer.oauth`  to get rid of dependencies on `satellizer.Oauth1` and `satellizer.Oauth2` and to provide methods to add new strategies, and actually renames it to `satellizer.provider_auth`.
3. refactors angular wrapping of `satellizer.Oauth1` and `satellizer.Oauth2` into config clause for eager initialization as actually nothing depends on them anymore. They still get registered with angular's $provider just in case it is also a backwards compatibility concern and also to show that unmodified test suites pass.
4. creates alias `satellizer.oauth` to `satellizer.provider_auth` for backwards compatibility.
5. adds test suite for `satellizer.provider_auth` new methods.

The minimum of methods that a `strategy` has to define is:
* `applies` - should return boolean value that indicates whether strategy is applicable to a given provider config. 
* `open` - meaning is the same as it was and is `satellizer.Oauth1` and `satellizer.Oauth2` modules.

This PR also makes it possible to extract Oauth1 and Oauth2 parts into separate modules which can be included/excluded at will.
As a result I was able to make a strategy that uses ruby's omniauth as a proxy for all the provider authentications. (I can add a PR with this separate module as well).

I'm not actually sure if you'd want the project to go in this direction, but let me know your thoughts.
I can add relevant `README` changes if you find this mergeable.

Some Notes on evaluating the PR:
* In this PR I haven't extracted `satellizer.Oauth1` and `satellizer.Oauth2` into modules as it would mean more significant re-arrangements in the code, thus making it impossible to rebase any other outstanding changes you may have on top of it or the other way around.
* I tricked indentation of the two config blocks for those to generate a less distracting diff against master.
* As you can see the existing test suites were untouched.
* Example app has been tested as well and everything is working without any modifications as before.