### PR TITLE
qs.parse(accessToken) renders empty object

### DIFF
--- a/examples/server/node/server.js
+++ b/examples/server/node/server.js
@@ -466,7 +466,6 @@ app.post('/auth/facebook', function(req, res) {
     if (response.statusCode !== 200) {
       return res.status(500).send({ message: accessToken.error.message });
     }
-    accessToken = qs.parse(accessToken);
 
     // Step 2. Retrieve profile information about the current user.
     request.get({ url: graphApiUrl, qs: accessToken, json: true }, function(err, response, profile) {


### PR DESCRIPTION
accessToken is a JSON object in itself. `qs.parse(accessToken)` would render an empty object.

There're `qs.parse(accessToken)` elsewhere in the code as well and may have the same issue.