### PR TITLE
In IE11 the hash starts with '#/' rather than '#' this breaks the readin...

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -675,8 +675,8 @@
                   popupWindowOrigin = popupWindow.location.host + ':' + popupWindow.location.port;
 
               if (popupWindowOrigin === documentOrigin && (popupWindow.location.search || popupWindow.location.hash)) {
-                var queryParams = popupWindow.location.search.substring(1).replace(/\/$/, '');
-                var hashParams = popupWindow.location.hash.substring(1).replace(/\/$/, '');
+                var queryParams = popupWindow.location.search.substring(1).replace(/[\/$]/, '');
+                var hashParams = popupWindow.location.hash.substring(1).replace(/[\/$]/, '');
                 var hash = utils.parseQueryString(hashParams);
                 var qs = utils.parseQueryString(queryParams);
 


### PR DESCRIPTION
...g of the access_token value.See issue https://github.com/sahat/satellizer/issues/337