### PR TITLE
Handle jwt-simple decode errors

### DIFF
--- a/examples/server/node/server.js
+++ b/examples/server/node/server.js
@@ -86,7 +86,15 @@ function ensureAuthenticated(req, res, next) {
     return res.status(401).send({ message: 'Please make sure your request has an Authorization header' });
   }
   var token = req.headers.authorization.split(' ')[1];
-  var payload = jwt.decode(token, config.TOKEN_SECRET);
+  
+  var payload = null;
+  try {
+    payload = jwt.decode(token, config.TOKEN_SECRET);
+  }
+  catch (err){
+    return res.status(401).send({message: err.message});
+  }
+  
   if (payload.exp <= moment().unix()) {
     return res.status(401).send({ message: 'Token has expired' });
   }


### PR DESCRIPTION
Decode with a bad token throw an error and server reply with status 500