### PR TITLE
Grammar error on the readme.md to show that IE9 users need polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ or use the CDN:
 <script src="//cdn.jsdelivr.net/satellizer/0.10.1/satellizer.min.js"></script>
 ```
 
-**Note:** Sattelizer uses [window.btoa](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa) and [window.atob](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/atob), so you still need to support **IE9** use the Base64 polyfill above.
+**Note:** Sattelizer uses [window.btoa](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/btoa) and [window.atob](https://developer.mozilla.org/en-US/docs/Web/API/WindowBase64/atob).  If you still need to support **IE9**, use the Base64 polyfill above.
 
 ## Usage
 


### PR DESCRIPTION
I fixed a grammar (I spelled it wrong on check in) showing users that they need to install the polyfill only if they need IE9 support.