### PR TITLE
improved windows live auth in examples

### DIFF
--- a/examples/client/partials/profile.html
+++ b/examples/client/partials/profile.html
@@ -74,6 +74,13 @@
         <button class="btn btn-sm btn-primary" ng-if="!user.yahoo" ng-click="link('yahoo')">
           <i class="ion-social-yahoo"></i> Link Yahoo Account
         </button>
+
+        <button class="btn btn-sm btn-danger" ng-if="user.live" ng-click="unlink('live')">
+          <i class="ion-social-windows"></i> Unlink Windows Live Account
+        </button>
+        <button class="btn btn-sm btn-primary" ng-if="!user.live" ng-click="link('live')">
+          <i class="ion-social-windows"></i> Link Windows Live Account
+        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
* added button to link/unlink windows live account to profile page
* changed the structure for the live account linking function to match the other providers and the comments (step 3a: link accounts, step 3b: new account) (was he other way round with wrong comments before)
* don't overwrite the existing profile name if one exists and correctly take the windows live username if no existing name is set