### PR TITLE
Add request configuration for POST requests with signup and login

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -226,12 +226,12 @@
             return oauth.authenticate(name, false, userData);
           };
 
-          $auth.login = function(user, redirect) {
-            return local.login(user, redirect);
+          $auth.login = function(user, redirect, reqConfig) {
+            return local.login(user, redirect, reqConfig);
           };
 
-          $auth.signup = function(user) {
-            return local.signup(user);
+          $auth.signup = function(user, reqConfig) {
+            return local.signup(user, reqConfig);
           };
 
           $auth.logout = function(redirect) {
@@ -416,18 +416,18 @@
       function($q, $http, $location, utils, shared, config) {
         var local = {};
 
-        local.login = function(user, redirect) {
+        local.login = function(user, redirect, reqConfig) {
           var loginUrl = config.baseUrl ? utils.joinUrl(config.baseUrl, config.loginUrl) : config.loginUrl;
-          return $http.post(loginUrl, user)
+          return $http.post(loginUrl, user, reqConfig)
             .then(function(response) {
               shared.setToken(response, redirect);
               return response;
             });
         };
 
-        local.signup = function(user) {
+        local.signup = function(user, reqConfig) {
           var signupUrl = config.baseUrl ? utils.joinUrl(config.baseUrl, config.signupUrl) : config.signupUrl;
-          return $http.post(signupUrl, user)
+          return $http.post(signupUrl, user, reqConfig)
             .then(function(response) {
               if (config.loginOnSignup) {
                 shared.setToken(response);


### PR DESCRIPTION
This PR adds the ability to specify request configuration for POST requests with signup and login. This is primarily for things like setting additional headers, or other such properties that you might use with an [$http.post](https://docs.angularjs.org/api/ng/service/$http#post) request