### PR TITLE
Fix facebook login for IE

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -47,7 +47,7 @@
           name: 'facebook',
           url: '/auth/facebook',
           authorizationEndpoint: 'https://www.facebook.com/v2.3/dialog/oauth',
-          redirectUri: window.location.origin + '/' || window.location.protocol + '//' + window.location.host + '/',
+          redirectUri: (window.location.origin || window.location.protocol + '//' + window.location.host) + '/',
           scope: ['email'],
           scopeDelimiter: ',',
           requiredUrlParams: ['display', 'scope'],


### PR DESCRIPTION
in IE, the redirectURI is transformed to 'undefined/' as window.location.origin is undefined, and as this is a string the logical condition supposed to work for IE was not working