### PR TITLE
Regex for email in signup.html not complete

### DIFF
--- a/examples/client/partials/signup.html
+++ b/examples/client/partials/signup.html
@@ -14,7 +14,7 @@
 
           <div class="form-group has-feedback" ng-class="{ 'has-error' : signupForm.email.$invalid && signupForm.email.$dirty }">
             <input class="form-control input-lg" type="email" id="email" name="email" ng-model="email" placeholder="Email" required
-            ng-pattern="/^[A-z]+[a-z0-9._]+@[a-z]+\.[a-z.]{2,5}$/">
+            ng-pattern="/^[-a-z0-9~!$%^&_=+}{\'?]+(.[-a-z0-9~!$%^&=+}{\'?]+)@([a-z0-9_][-a-z0-9_](.[-a-z0-9]+)*.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}))(:[0-9]{1,5})?$/i">
             <span class="ion-at form-control-feedback"></span>
             <div class="help-block text-danger" ng-if="signupForm.email.$dirty" ng-messages="signupForm.email.$error">
               <div ng-message="required">Your email address is required.</div>


### PR DESCRIPTION
Currently , email adresses like abc123@xyz.edu.in etc don't work. The regex pattern used in signup.html(Line 17) is very short and doesn't take account of such email ids.

This regex fixes such issues :

required ng-pattern="/^[-a-z0-9~!$%^&_=+}{\'?]+(.[-a-z0-9~!$%^&=+}{\'?]+)@([a-z0-9_][-a-z0-9_](.[-a-z0-9]+)*.(aero|arpa|biz|com|coop|edu|gov|info|int|mil|museum|name|net|org|pro|travel|mobi|[a-z][a-z])|([0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}))(:[0-9]{1,5})?$/i"

Taken from http://emailregex.com/