### PR TITLE
nested tokenroot possible with dot notation in configuration

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -312,8 +312,9 @@
           }
 
           if (!token && response) {
-            token = config.tokenRoot && response.data[config.tokenRoot] ?
-              response.data[config.tokenRoot][config.tokenName] : response.data[config.tokenName];
+            var tokenData = config.tokenRoot.split(".").reduce(function(o, x) { return o[x] }, response.data);
+            token = config.tokenRoot && tokenData ?
+              tokenData[config.tokenName] : response.data[config.tokenName];
           }
 
           if (!token) {


### PR DESCRIPTION
As I am following the JSON API as defined on http://jsonapi.org/, I had the need of a more deeply nested structure.

Based on SO answer http://stackoverflow.com/questions/10934664/convert-string-in-dot-notation-to-get-the-object-reference

Linked to your last comment on https://github.com/sahat/satellizer/pull/262