### PR TITLE
'response' is not defined.

### DIFF
--- a/examples/client/controllers/profile.js
+++ b/examples/client/controllers/profile.js
@@ -14,7 +14,7 @@ angular.module('MyApp')
         .then(function() {
           toastr.success('Profile has been updated');
         })
-        .catch(function() {
+        .catch(function(response) {
           toastr.error(response.data.message, response.status);
         });
     };


### PR DESCRIPTION
## Why:

* 'response' is undefined when it is called from the toastr error message

## Change:

* Simply added 'response' to function() on line 17 of examples/client/controllers/profile.js