### PR TITLE
Issues573and574

### DIFF
--- a/examples/client/partials/signup.html
+++ b/examples/client/partials/signup.html
@@ -27,7 +27,7 @@
             </div>
           </div>
           <div class="form-group has-feedback" ng-class="{ 'has-error' : signupForm.confirmPassword.$invalid && signupForm.confirmPassword.$dirty }">
-            <input password-match="user.password" class="form-control input-lg" type="password" name="confirmPassword" ng-model="user.confirmPassword" placeholder="Confirm Password">
+            <input password-match="user.password" class="form-control input-lg" type="password" name="confirmPassword" ng-model="confirmPassword" placeholder="Confirm Password">
             <span class="ion-key form-control-feedback"></span>
             <div class="help-block text-danger" ng-if="signupForm.confirmPassword.$dirty" ng-messages="signupForm.confirmPassword.$error">
               <div ng-message="compareTo">Password must match.</div>


### PR DESCRIPTION
Closes #573 and #574
 
Fixed two issues with the java dropwizard server example
- error logging in through facebook (possibly fb API changed?)
- errors parsing JSON from the client:
 1) trying to sign up with email, due to the confirmPassword field being sent along as part of  the User JSON) 
2) when unlinking from a provider (e.g. facebook),  the API expects the provider name as a path param, but the client sends it in the request body