### PR TITLE
Fixed two mobile bugs

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -637,7 +637,7 @@
           Popup.url = url;
 
           var stringifiedOptions = Popup.stringifyOptions(Popup.prepareOptions(options));
-          var windowName = config.cordova ? '_blank' : name;
+          var windowName = '_blank';
 
           Popup.popupWindow = window.open(url, windowName, stringifiedOptions);
 

--- a/satellizer.js
+++ b/satellizer.js
@@ -641,7 +641,7 @@
 
           Popup.popupWindow = window.open(url, windowName, stringifiedOptions);
 
-          window.popup = Popup.popupWindow;
+          $window.popup = Popup.popupWindow;
 
           if (Popup.popupWindow && Popup.popupWindow.focus) {
             Popup.popupWindow.focus();


### PR DESCRIPTION
I ran into two bugs on mobile which I've fixed in this PR:
- Pop up windows are not successfully closed after polling for the access token is complete on mobile. I fixed this by using Angular's $window wrapper instead of using the window object directly
- Pop up windows were not successfully being opened in Google Chrome iOS (try this on your demo site w/ twitter). I fixed that by just using _blank as the window name in all situations. If you want to retain the dynamic window name for some reason, you could do a userAgent string check for CriOS, but figured this was easier. I tested on Android Chrome, Safari iOS6, Chrome iOS6, and Google Chrome OSX.
