### PR TITLE
Fix for commonjs - Webpack, Browserify etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "node ./examples/server/node/server.js",
     "test": "karma start"
   },
-  "main": "satellizer.min.js",
+  "main": "satellizer.js",
   "homepage": "https://github.com/sahat/satellizer",
   "bugs": "https://github.com/sahat/satellizer/issues",
   "repository": {

--- a/satellizer.js
+++ b/satellizer.js
@@ -3,6 +3,11 @@
  * (c) 2015 Sahat Yalkabov
  * License: MIT
  */
+
+if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports) {
+  module.exports = 'satellizer';
+}
+
 (function(window, angular, undefined) {
   'use strict';
 


### PR DESCRIPTION
This fix allows satellizer to be included in a CommonJS environment such as Webpack or Browserify.

e.g.

```js
var angular = require('angular');
var satellizer = require('satellizer');

angular.module('app', [satellizer]);
```
Or in ES6

```js
import angular from 'angular';
import satellizer from 'satellizer';

angular.module('app', [satellizer]);
```

P.S. this is also the way `ui-router` [does it](https://github.com/angular-ui/ui-router/blob/master/release/angular-ui-router.js#L9-L11)