### PR TITLE
Allowing PUT on me()-function

### DIFF
--- a/examples/server/python/app.py
+++ b/examples/server/python/app.py
@@ -120,7 +120,7 @@ def index():
     return send_file(os.path.join(client_path, 'index.html'))
 
 
-@app.route('/api/me')
+@app.route('/api/me', methods=['GET', 'PUT'])
 @login_required
 def me():
     user = User.query.filter_by(id=g.user_id).first()


### PR DESCRIPTION
When updating your profile with python/Flask server-side, you get a '405 Method not allowed' back. This is because "By default, a route only answers to GET requests" (from: http://flask.pocoo.org/docs/0.10/quickstart/#http-methods).
However, updating your profile uses PUT (see [this line](https://github.com/sahat/satellizer/blob/master/examples/client/services/account.js#L8)).

I added the 'methods' argument to the route() decorator on the me()-function to allow for PUT requests. This resolves this issue.

Is this ok?