### PR TITLE
Fix ruby example for facebook

### DIFF
--- a/examples/server/ruby/app/models/oauth/facebook.rb
+++ b/examples/server/ruby/app/models/oauth/facebook.rb
@@ -1,7 +1,7 @@
 module Oauth
   class Facebook < Oauth::Base
-    ACCESS_TOKEN_URL = 'https://graph.facebook.com/v2.3/oauth/access_token'
-    DATA_URL = 'https://graph.facebook.com/v2.3/me'
+    ACCESS_TOKEN_URL = 'https://graph.facebook.com/v2.5/oauth/access_token'
+    DATA_URL = 'https://graph.facebook.com/v2.5/me'
 
     def get_data
       response = @client.get(DATA_URL, access_token: @access_token, fields: 'first_name, last_name, email, gender, about, address, link, website, picture')

--- a/examples/server/ruby/app/models/oauth/facebook.rb
+++ b/examples/server/ruby/app/models/oauth/facebook.rb
@@ -4,7 +4,7 @@ module Oauth
     DATA_URL = 'https://graph.facebook.com/v2.5/me'
 
     def get_data
-      response = @client.get(DATA_URL, access_token: @access_token, fields: 'first_name, last_name, email, gender, about, address, link, website, picture')
+      response = @client.get(DATA_URL, access_token: @access_token, fields: 'first_name, last_name, email, gender, about, link, website, picture')
       @data = JSON.parse(response.body).with_indifferent_access
       @data['image_url'] = @data['picture']['data']['url'] if @data['picture'].present?
       @uid = @data[:id] ||= @data[:sub]


### PR DESCRIPTION
Actually an error is raised when authenticating with Facebook as shown below:

```javascript
{"error"=>{"message"=>"(#100) Tried accessing nonexisting field (address) on node type (User)", "type"=>"OAuthException", "code"=>100, "fbtrace_id"=>"Ejr+zuaCk+u"}}
```
By removing the address field, the problem is solved. Also I upgrade facebook API to 2.5 which is actually being used on the client and this way they both match.
