### PR TITLE
Switch to spaces for scope delimitation for Bitbucket

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -140,7 +140,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
           redirectUri: window.location.origin + '/',
           requiredUrlParams: ['scope'],
           scope: ['email'],
-          scopeDelimiter: ',',
+          scopeDelimiter: ' ',
           oauthType: '2.0',
           popupOptions: { width: 1028, height: 529 }
         }


### PR DESCRIPTION
Bitbucket will respond with an error if more than one scope is submitted and a comma used as the delimiter.