### PR TITLE
Improved popup error handling.

### DIFF
--- a/test/popup.spec.js
+++ b/test/popup.spec.js
@@ -51,6 +51,29 @@ describe('SatellizerPopup', function() {
     expect(angular.isObject(open)).toBe(true);
   });
 
+  it('should handle the case when popup redirect has occured but no parameters are set', function() {
+    this.popup.popupWindow = {
+      location: {
+        host: document.location.host
+      }
+    };
+    var open = this.popup.pollPopup();
+    var error;
+    open.catch(function (err) {
+      error = err;
+    });
+    this.$interval.flush(300);
+    expect(error).toBeDefined();
+  });
 
+  it('should handle the case when popup is closed', function() {
+    var open = this.popup.pollPopup();
+    var error;
+    open.catch(function (err) {
+      error = err;
+    });
+    this.$interval.flush(300);
+    expect(error).toBeDefined();
+  });
 });
 


### PR DESCRIPTION
While trying to resolve the problem that I had (described in https://github.com/sahat/satellizer/issues/727), I figured out that it could be helpful for others to have some better error handling in pollPopup method (it would for sure had saved me some time!).

There are two changes.

First one is simple: if popup is closed by somebody else, propagate corresponding error message. Seemed a reasonable thing to do, and I just noticed that there were some requests for it in https://github.com/sahat/satellizer/issues/706. I have the same situation with spinner as those guys, so getting a reject on promise is important in order to inform the user about failed attempt of login.

Second one is inspired by https://github.com/sahat/satellizer/issues/727 - I had a situation there where redirect happened but query params were not set. Satellizer continued to do polling forever in that case.
I believe that if we get in such state, where redirect occurred but query parameters are not set, we can safely assume that there is no way to get in state where those query parameters will be set again, so we can stop polling and return appropriate error message.
I also found very similar case in https://github.com/sahat/satellizer/issues/629, so it would be helpful in that case also.

