### PR TITLE
fix wrong token given after successfull authentication on ruby example

### DIFF
--- a/examples/server/ruby/app/controllers/auth_controller.rb
+++ b/examples/server/ruby/app/controllers/auth_controller.rb
@@ -36,7 +36,7 @@ class AuthController < ApplicationController
     if @oauth.authorized?
       @user = User.from_auth(@oauth.formatted_user_data, current_user)
       if @user
-        render_success(token: @oauth.access_token, authentication_token: @user.authentication_token, id: @user.id)
+        render_success(token: Token.encode(@user.id), id: @user.id)
       else
         render_error "This #{params[:provider]} account is used already"
       end

--- a/examples/server/ruby/app/models/token.rb
+++ b/examples/server/ruby/app/models/token.rb
@@ -7,8 +7,6 @@ class Token
   def initialize token
     @payload = JWT.decode(token, JWT_SECRET, JWT_ALGORITHM).first.with_indifferent_access
     @user_id = @payload[:user_id]
-  rescue JWT::DecodeError
-    nil
   end
 
   def valid?


### PR DESCRIPTION
The original implementation caused  error on the JWT decoder because of the wrong token