### PR TITLE
Add documentation skimming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ angular.module('MyApp', ['satellizer'])
     $authProvider.facebook({
       clientId: 'Facebook App ID'
     });
+    
+    // if used solely on the client side, set responseType to "token"
+    $authProvider.facebook({
+      clientId: 'Facebook App ID',
+      responseType: 'token'
+    });
 
     $authProvider.google({
       clientId: 'Google Client ID'
@@ -578,7 +584,7 @@ $auth.signup(user)
 
 #### `$auth.authenticate(name, [userData])`
 
-Starts the OAuth 1.0 or the OAuth 2.0 authorization flow by opening a popup window.
+Starts the OAuth 1.0 or the OAuth 2.0 authorization flow by opening a popup window. If used client side, [`responseType: "token"`](#authentication-flow) is required in the provider setup to get the actual access token. 
 
 ##### Parameters
 


### PR DESCRIPTION
I searched for half an hour, why I didn't get a valid access token, until I figured out that I need to set `responseType: "token"` in the provider's setup. Seriously, this was missing in the documentation and developers are lazy, so I added it. 