### PR TITLE
Manual authorization code exchange

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -529,7 +529,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
                   // Satellizer's magic by doing authorization code exchange and
                   // saving a token manually.
                   if (defaults.responseType === 'token' || !defaults.url) {
-                    defer.resolve(oauthData);
+                    return defer.resolve(oauthData);
                   }
 
                 if (oauthData.state && oauthData.state !== storage.get(stateName)) {


### PR DESCRIPTION
I'm integrating with an existing system where we already have authorization code exchange setup already.
Surely this is meant to include a return statement so as to prevent the following exchangeForToken call?