### PR TITLE
fixing satellizer dependency on index.html

### DIFF
--- a/examples/client/index.html
+++ b/examples/client/index.html
@@ -41,7 +41,7 @@
 <script src="/vendor/angular-sanitize.js"></script>
 <script src="/vendor/angular-ui-router.js"></script>
 <script src="/vendor/angular-toastr.tpls.js"></script>
-<script src="/vendor/satellizer.js"></script>
+<script src="//cdn.jsdelivr.net/satellizer/0.14.0/satellizer.min.js"></script>
 
 <!-- Application Code -->
 <script src="/app.js"></script>


### PR DESCRIPTION
The index.html references an inexistent vendor/satellizer.js file.
Changing src to latest CDN version.