### PR TITLE
Popup reject propogation

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -522,7 +522,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
                 openPopup = popup.open(url, defaults.name, defaults.popupOptions, defaults.redirectUri).pollPopup(defaults.redirectUri);
               }
 
-              return openPopup
+              openPopup
                 .then(function(oauthData) {
                   // When no server URL provided, return popup params as-is.
                   // This is for a scenario when someone wishes to opt out from
@@ -540,6 +540,8 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
                   }
 
                   defer.resolve(Oauth2.exchangeForToken(oauthData, userData));
+                }, function (err) {
+                  defer.reject(err);
                 });
             });
 


### PR DESCRIPTION
Calling $auth.authenticate was not getting any rejected notices when the popup gets closed. The deferred being returned was not being rejected.

The 'return' statement looks misleading, as it is encapsulated inside a timeout, and thus nothing is actually being returned.

Changed to actually listen to the popup rejection and then reject the parent deferred.