### PR TITLE
Reject the deferred when the popup is closed on Cordova

### DIFF
--- a/satellizer.js
+++ b/satellizer.js
@@ -747,6 +747,10 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
             deferred.reject('Authorization Failed');
           });
 
+          Popup.popupWindow.addEventListener('exit', function() {
+            deferred.reject('Popup exit');
+          });
+
           return deferred.promise;
         };
 


### PR DESCRIPTION
On Android, with Cordova, when the user uses the back button of his device, the popup is closed but the deferred is not rejected.

This PR corrects this behavior.