### PR TITLE
Fix semver

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "main": "dist/satellizer.js",
   "homepage": "https://github.com/sahat/satellizer",
   "dependencies": {
-    "angular": ">=1.3.x && <= 1.5.x"
+    "angular": "1.3.x - 1.5.x"
   }
 }


### PR DESCRIPTION
Addresses #873, ENORESTARGET when installing on bower by correcting the semver reference to Angluar.

According to https://semver.npmjs.com/, an inclusive range of stable releases is indicated with a hyphen, not using `&&`. This change should allow the library to be installed by bower.