### PR TITLE
Fix annotations to work with strictDI

### DIFF
--- a/src/authProvider.ts
+++ b/src/authProvider.ts
@@ -118,3 +118,5 @@ export default class AuthProvider {
     };
   }
 }
+
+AuthProvider.prototype.$get.$inject = ['SatellizerShared', 'SatellizerLocal', 'SatellizerOAuth'];

--- a/src/interceptor.ts
+++ b/src/interceptor.ts
@@ -35,3 +35,5 @@ export default class Interceptor implements angular.IHttpInterceptor {
     return config;
   };
 }
+
+Interceptor.Factory.$inject = ['SatellizerConfig', 'SatellizerShared', 'SatellizerStorage'];

--- a/src/ng1.ts
+++ b/src/ng1.ts
@@ -21,7 +21,7 @@ angular.module('satellizer', [])
   .service('SatellizerOAuth1', OAuth1)
   .service('SatellizerStorage', Storage)
   .service('SatellizerInterceptor', Interceptor)
-  .config(($httpProvider) => new HttpProviderConfig($httpProvider));
+  .config(['$httpProvider', ($httpProvider) => new HttpProviderConfig($httpProvider)]);
 
 export default 'satellizer';
 

--- a/test/annotations.spec.ts
+++ b/test/annotations.spec.ts
@@ -1,0 +1,15 @@
+import satellizer from './../src/ng1';
+
+describe('angular annotations', () => {
+
+  beforeEach(angular.mock.module(satellizer));
+
+  beforeEach(() => {
+    angular.mock.inject.strictDi(true);
+  });
+
+  it('should create the injector without errors', angular.mock.inject(['$auth', ($auth) => {
+    expect($auth).toBeTruthy();
+  }]));
+
+});


### PR DESCRIPTION
A cleaner solution might be to use [ng-annotate](https://github.com/olov/ng-annotate), however there isn't a rollup plugin for it

Fixes https://github.com/sahat/satellizer/issues/878