### PR TITLE
Update bower.json for more compatibility

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "main": "dist/satellizer.js",
   "homepage": "https://github.com/sahat/satellizer",
   "dependencies": {
-    "angular": "1.3.x - 1.5.x"
+    "angular": "1.3.0 - 1.5.x"
   }
 }


### PR DESCRIPTION
Some of package managers do not yet support a wildcard package version at the first version in versions range in the package's dependencies restrictions. More info & example https://github.com/sahat/satellizer/issues/901