### PR TITLE
Allow expiry of 0

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -76,7 +76,7 @@ class Shared {
           const base64Url = token.split('.')[1];
           const base64 = base64Url.replace('-', '+').replace('_', '/');
           const exp = JSON.parse(this.$window.atob(base64)).exp;
-          if (exp) {  // JWT with an optonal expiration claims
+          if (typeof exp === 'number') {  // JWT with an optonal expiration claims
             return (Math.round(new Date().getTime() / 1000) >= exp) ? false : true;
           }
         } catch (e) {


### PR DESCRIPTION
This caught me out when I was testing my code's behaviour to expired tokens, I figured a time with 0 would be expired but it's not.