### PR TITLE
Add new user during auth with github

### DIFF
--- a/examples/server/node/server.js
+++ b/examples/server/node/server.js
@@ -319,6 +319,8 @@ app.post('/auth/github', function(req, res) {
           user.github = profile.id;
           user.picture = profile.avatar_url;
           user.displayName = profile.name;
+          user.email = profile.email;
+
           user.save(function() {
             var token = createJWT(user);
             res.send({ token: token });


### PR DESCRIPTION
If backnd (server.js) try to add second user after auth with github, insert new user to MongoDB is broken. On 'email' field is index and can not be null.