### PR TITLE
Fix microsoft live `The access token isn't valid` error

### DIFF
--- a/dist/satellizer.js
+++ b/dist/satellizer.js
@@ -564,7 +564,7 @@
                         if (popupWindowPath === redirectUriPath) {
                             if (_this.popup.location.search || _this.popup.location.hash) {
                                 var query = parseQueryString(_this.popup.location.search.substring(1).replace(/\/$/, ''));
-                                var hash = parseQueryString(_this.popup.location.hash.substring(1).replace(/[\/$]/, ''));
+                                var hash = parseQueryString(_this.popup.location.hash.substring(1);
                                 var params = angular.extend({}, query, hash);
                                 if (params.error) {
                                     reject(new Error(params.error));


### PR DESCRIPTION
This `replace` removes _valid_ characters from the token.
