### PR TITLE
linkedin doesn't support response type token

### DIFF
--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -83,7 +83,7 @@ export default class OAuth2 {
       const url = [this.defaults.authorizationEndpoint, this.buildQueryString()].join('?');
 
       this.SatellizerPopup.open(url, name, popupOptions, redirectUri).then((oauth: any): void|angular.IPromise<any>|angular.IHttpPromise<any> => {
-        if (responseType === 'token' || !this.defaults.url) {
+        if (responseType === 'token' || responseType === 'code' && name === 'linkedin' || !this.defaults.url) {
           return resolve(oauth);
         }
 


### PR DESCRIPTION
linkedin api support only 'code' so i added this to the check
