### PR TITLE
Fix 400 Unable to Parse JSON for Google OAuth

### DIFF
--- a/examples/server/java/src/main/java/com/example/helloworld/resources/AuthResource.java
+++ b/examples/server/java/src/main/java/com/example/helloworld/resources/AuthResource.java
@@ -253,7 +253,9 @@ public class AuthResource {
 
     @NotBlank
     String code;
-
+    
+    String state;
+	  
     public String getClientId() {
       return clientId;
     }
@@ -265,6 +267,10 @@ public class AuthResource {
     public String getCode() {
       return code;
     }
+	  
+    public String getState() {
+      return state;
+    }	  
   }
 
   /*


### PR DESCRIPTION
Google response contains state field, server throws 400 -  Unable to process JSON. adding this field to payload classes fixes the problem.

{"code":"***","clientId":"*****","redirectUri":"http://localhost:3000","state":"aeanx8630v"}