### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 ```
 ```html
 <!-- Satellizer CDN -->
-<script src="https://cdn.jsdelivr.net/satellizer/0.15.5/satellizer.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/satellizer@0.15.5/dist/satellizer.min.js"></script>
 ```
 
 #### <img src="https://upload.wikimedia.org/wikipedia/commons/d/db/Npm-logo.svg" height="22" align="top"> NPM


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/satellizer.

Feel free to ping me if you have any questions regarding this change.