### PR TITLE
Allow authorizationEndpoint with query param

### DIFF
--- a/src/oauth2.ts
+++ b/src/oauth2.ts
@@ -80,7 +80,7 @@ export default class OAuth2 {
         this.SatellizerStorage.set(stateName, state);
       }
 
-      const url = [this.defaults.authorizationEndpoint, this.buildQueryString()].join('?');
+      const url = [this.defaults.authorizationEndpoint, this.buildQueryString()].join(this.defaults.authorizationEndpoint.indexOf('?') === -1 ? '?' : '&');
 
       this.SatellizerPopup.open(url, name, popupOptions, redirectUri).then((oauth: any): void|angular.IPromise<any>|angular.IHttpPromise<any> => {
         if (responseType === 'token' || !this.defaults.url) {


### PR DESCRIPTION
Hi,

When authorization endpoint contains a query param, the URL generated for the Satellizer Popup is not valid due to wrong query param concatenation.

See a detailed bug report in https://github.com/gravitee-io/issues/issues/2672

